### PR TITLE
[Fix/tayside v0.3.6 tayside] Fixes registered users can't see list of organizations

### DIFF
--- a/ckanext/datarequests/actions.py
+++ b/ckanext/datarequests/actions.py
@@ -155,12 +155,8 @@ def datarequest_create(context, data_dict):
 
     # If org name is passed instead of id, get the id of the organization
     org_id = tk.get_action('organization_show')(context, {'id':data_dict['organization_id']})      
-    logging.error(data_dict)
-    logging.error('************')
     data_dict['organization_id'] = org_id['id']             
     
-    logging.error(data_dict)
-
     # Validate data
     validator.validate_datarequest(context, data_dict)
 

--- a/ckanext/datarequests/actions.py
+++ b/ckanext/datarequests/actions.py
@@ -153,6 +153,14 @@ def datarequest_create(context, data_dict):
     # Check access
     tk.check_access(constants.DATAREQUEST_CREATE, context, data_dict)
 
+    # If org name is passed instead of id, get the id of the organization
+    org_id = tk.get_action('organization_show')(context, {'id':data_dict['organization_id']})      
+    logging.error(data_dict)
+    logging.error('************')
+    data_dict['organization_id'] = org_id['id']             
+    
+    logging.error(data_dict)
+
     # Validate data
     validator.validate_datarequest(context, data_dict)
 

--- a/ckanext/datarequests/helpers.py
+++ b/ckanext/datarequests/helpers.py
@@ -46,3 +46,10 @@ def get_open_datarequests_badge(show_badge):
                                  {'comments_count': get_open_datarequests_number()})
     else:
         return ''
+def get_available_organizations_all():                                                                                                        
+    '''Get the organization lists for every user'''                                                                                           
+    context = {'model': model, 'session': model.Session, 'user': tk.c.user}                                                                   
+    data_dict = {}                                                                                                                            
+    return tk.get_action('organization_list')(context,data_dict)
+    #return logic.get_action('organization_show')(context,data_dict)                                                                          
+    #return logic.get_action('organization_list_for_user')(context, {'permission':'read'})

--- a/ckanext/datarequests/helpers.py
+++ b/ckanext/datarequests/helpers.py
@@ -51,5 +51,3 @@ def get_available_organizations_all():
     context = {'model': model, 'session': model.Session, 'user': tk.c.user}                                                                   
     data_dict = {}                                                                                                                            
     return tk.get_action('organization_list')(context,data_dict)
-    #return logic.get_action('organization_show')(context,data_dict)                                                                          
-    #return logic.get_action('organization_list_for_user')(context, {'permission':'read'})

--- a/ckanext/datarequests/plugin.py
+++ b/ckanext/datarequests/plugin.py
@@ -186,7 +186,8 @@ class DataRequestsPlugin(p.SingletonPlugin):
             'get_comments_number': helpers.get_comments_number,
             'get_comments_badge': helpers.get_comments_badge,
             'get_open_datarequests_number': helpers.get_open_datarequests_number,
-            'get_open_datarequests_badge': partial(helpers.get_open_datarequests_badge, self._show_datarequests_badge)
+            'get_open_datarequests_badge': partial(helpers.get_open_datarequests_badge, self._show_datarequests_badge),
+            'get_available_organizations_all': helpers.get_available_organizations_all
         }
 
     ######################################################################

--- a/ckanext/datarequests/templates/datarequests/snippets/datarequest_form.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/datarequest_form.html
@@ -3,7 +3,7 @@
 {% set title = data.get('title', '') %}
 {% set description = data.get('description', '') %}
 {% set organization_id = data.get('organization_id', h.get_request_param('organization')) %}
-{% set organizations_available = h.organizations_available('read') %}
+{% set organizations_available = h.get_available_organizations_all() %}
 
 {# This provides a full page that renders a form for publishing a dataset. It can
 then itself be extended to add/remove blocks of functionality. #}
@@ -29,8 +29,8 @@ then itself be extended to add/remove blocks of functionality. #}
            <option value="" {% if not selected_org and data.id %} selected="selected" {% endif %}>{{ _('No organization') }}</option>
         {% endif %}
         {% for organization in organizations_available %}
-          {% set selected_org = (organization.id == organization_id)  %}
-          <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ organization.name }}</option>
+          {% set selected_org = organization  %}
+          <option value="{{ organization }}" {% if selected_org %} selected="selected" {% endif %}>{{ organization }}</option>
         {% endfor %}
       </select>
     </div>


### PR DESCRIPTION
This PR fixes

`The users any other than ckan-admin can not see list of organizations in the dropdown menu while creating a datarequest`
issue: https://gitlab.com/datopian/core/support/issues/191 

## Summary

Previously the helper function `organizations_available` was being used to get the names of organizations for the drop down menu while creating a datarequest but it wasn't allowing any user other than the admin to get the list of organizations, so in order to fix that a new helper function is created ( `get_available_organizations_all`) which uses `ckan.logic.action.get.organization_list(context, data_dict)` api to get the list of names of organizations. The name of organization is further converted to `organization_id` in `actions.py` to avoid getting `validation error`.

## Files changed

- `actions.py`
  - organization_id is obtained by using `organization_show` api which takes name of the organization as input and returns information of that organization, from where id can be retrieved
- `plugin.py`
  - The new helper function (`get_available_organizations_all`) is added to `get_helpers(self)`  
- `helper.py`
  - New helper function is added which uses `organization_list` api to get the list of organizations
- `datarequests/snippets/datarequest_form.html`
  - Previous helper function is replaced by new one
  - Organization name is used in the drop down menu and the check for organization_id is removed

## Outcome
Test user can now create a datarequest with names of organizations showing in the dropdown list.


![Screenshot from 2020-03-04 19-54-55](https://user-images.githubusercontent.com/57398621/75891927-4e2b2100-5e52-11ea-8a72-2620954c23f1.png)
![Screenshot from 2020-03-04 19-54-31](https://user-images.githubusercontent.com/57398621/75891936-51bea800-5e52-11ea-887a-68c3e2d74ec9.png)
![Screenshot from 2020-03-04 19-54-44](https://user-images.githubusercontent.com/57398621/75891942-54b99880-5e52-11ea-9f82-92038785fa1d.png)

