### PR TITLE
Fix/tayside Get email notification on creating, closing and commenting on a datarequest

### DIFF
--- a/ckanext/datarequests/actions.py
+++ b/ckanext/datarequests/actions.py
@@ -132,7 +132,7 @@ def _get_datarequest_involved_users(context, datarequest_dict):
     users.update([comment['user_id'] for comment in datarequest_comment_list(new_context, {'datarequest_id': datarequest_id})])
 
     if datarequest_dict['organization']:
-        users.update([user['id'] for user in datarequest_dict['organization']['users']])
+        users.update([user['name'] for user in datarequest_dict['organization']['users']])
 
     # Notifications are not sent to the user that performs the action
     users.discard(context['auth_user_obj'].id)
@@ -215,8 +215,8 @@ def datarequest_create(context, data_dict):
     datarequest_dict = _dictize_datarequest(data_req)
 
     if datarequest_dict['organization']:
-        users = set([user['id'] for user in datarequest_dict['organization']['users']])
-        users.discard(context['auth_user_obj'].id)
+        users = set([user['name'] for user in datarequest_dict['organization']['users']])
+        users.discard(context['auth_user_obj'].name)
         _send_mail(users, 'new_datarequest', datarequest_dict)
 
     return datarequest_dict

--- a/ckanext/datarequests/actions.py
+++ b/ckanext/datarequests/actions.py
@@ -130,13 +130,17 @@ def _get_datarequest_involved_users(context, datarequest_dict):
     users = set()
     users.add(datarequest_dict['user_id'])
     users.update([comment['user_id'] for comment in datarequest_comment_list(new_context, {'datarequest_id': datarequest_id})])
-
+    
+    user_info = []
+    
     if datarequest_dict['organization']:
-        users.update([user['name'] for user in datarequest_dict['organization']['users']])
-
+        for user in datarequest_dict['organization']['users']:                                                                 
+            user_info.append(tk.get_action('user_show')(context,{'id':user['name']}))
+        users.update([userid['id'] for userid in user_info]) 
+    
     # Notifications are not sent to the user that performs the action
-    users.discard(context['auth_user_obj'].id)
-    logging.error(users)
+    users.discard(context['auth_user_obj'].id) 
+    
     return users
 
 

--- a/ckanext/datarequests/templates/emails/bodies/close_datarequest.txt
+++ b/ckanext/datarequests/templates/emails/bodies/close_datarequest.txt
@@ -1,0 +1,15 @@
+Dear {{ user.fullname }},
+
+"{{ datarequest['title'] }}" data request has been closed. Check the accepted dataset in CKAN!
+
+You are receiving this notifications because:
+
+* You are the owner of the data request 
+* You are a member of the organization where the data request has been created
+* You are following the data request
+* You have posted a comment in the data request
+
+--
+
+Best Regards,
+{{ site_title }} Team -- {{ site_url }}

--- a/ckanext/datarequests/templates/emails/bodies/new_comment.txt
+++ b/ckanext/datarequests/templates/emails/bodies/new_comment.txt
@@ -1,0 +1,15 @@
+Dear {{ user.fullname }},
+
+A user has commented in the "{{ datarequest['title'] }}" data request. Check this new comment just in case you want to give it a reply.
+
+You are receiving this notifications because:
+
+* You are the owner of the data request
+* You are a member of the organization where the data request has been created
+* You are following the data request
+* You have posted a comment in the data request
+
+--
+
+Best Regards,
+{{ site_title }} Team -- {{ site_url }}

--- a/ckanext/datarequests/templates/emails/bodies/new_datarequest.txt
+++ b/ckanext/datarequests/templates/emails/bodies/new_datarequest.txt
@@ -1,0 +1,12 @@
+Dear {{ user.fullname }},
+
+The "{{ datarequest['title'] }}" data request has been created in the organization "{{ datarequest['organization']['title'] }}".
+
+Check if you can give it an answer by accessing the Data Request tab that you will find in your CKAN instance.
+
+You are receiving this notification because you are member of the mentioned organization.
+
+--
+
+Best Regards,
+{{ site_title }} Team -- {{ site_url }}

--- a/ckanext/datarequests/templates/emails/subjects/close_datarequest.txt
+++ b/ckanext/datarequests/templates/emails/subjects/close_datarequest.txt
@@ -1,0 +1,1 @@
+[{{ site_title }}] Data Request {{ datarequest['title'] }} has been closed!

--- a/ckanext/datarequests/templates/emails/subjects/new_comment.txt
+++ b/ckanext/datarequests/templates/emails/subjects/new_comment.txt
@@ -1,0 +1,1 @@
+[{{ site_title }}] Data Request {{ datarequest['title'] }} has a new comment!

--- a/ckanext/datarequests/templates/emails/subjects/new_datarequest.txt
+++ b/ckanext/datarequests/templates/emails/subjects/new_datarequest.txt
@@ -1,0 +1,1 @@
+[{{ site_title }}] Data Request {{ datarequest['title'] }} created in organization {{ datarequest['organization']['title'] }}!

--- a/ckanext/datarequests/validator.py
+++ b/ckanext/datarequests/validator.py
@@ -70,7 +70,7 @@ def validate_comment(context, request_data):
 
     # Check if the data request exists
     try:
-        tk.get_action(constants.DATAREQUEST_SHOW)(context, {'id': request_data['datarequest_id']})
+        datarequest = tk.get_action(constants.DATAREQUEST_SHOW)(context, {'id': request_data['datarequest_id']})
     except Exception:
         raise tk.ValidationError({tk._('Data Request'): [tk._('Data Request not found')]})
 
@@ -79,3 +79,5 @@ def validate_comment(context, request_data):
 
     if len(comment) > constants.COMMENT_MAX_LENGTH:
         raise tk.ValidationError({tk._('Comment'): [tk._('Comments must be a maximum of %d characters long') % constants.COMMENT_MAX_LENGTH]})
+    
+    return datarequest


### PR DESCRIPTION
This PR adds the code to send emails to the user
Fixes: https://gitlab.com/datopian/core/support/issues/190

**NOTE: SMTP server might be needed to setup for this in the `.env` file, this was tested using https://mailtrap.io/**

Followed the code from https://github.com/conwetlab/ckanext-datarequests/tree/v1.0.0
to add code for sending email whenever creating,closing or commenting on a datarequest.

## Files Changed

* actions.py
  * Added two new functions
    * def _get_datarequest_involved_users(context, datarequest_dict): returns `users` involved in the datarequest thread
    * def _send_mail(user_ids, action_type, datarequest): sends email using email templates
* validator.py
  * `validate_comment(context, request_data)` returns `datarequest`

## New files added

* templates/emails
  * bodies
    * close_datarequest.txt
    * new_comment.txt
    * new_datarequest.txt
  * subjects

    * close_datarequest.txt
    * new_comment.txt
    * new_datarequest.txt

## Working

These are the conditions under which email notification is sent to the users

* The user must select an organization from the dropdown menu to create a request
* The email is sent to the org_admin when a user creates and closes a datarequest
* If the sys_admin closes it, the email is sent to both org_admin and the user who created it.
* If a user comments on the datarequest created by some other user the email is sent to both the user who created the datarequest and the org_admin
* If the users comment on a datarequest created by them, the email is sent to the org_admin only or the users involved in the thread.